### PR TITLE
Pass board to set_board_option_value in data-dir option

### DIFF
--- a/R/data-dir.R
+++ b/R/data-dir.R
@@ -47,7 +47,7 @@ new_data_dir_option <- function(value = blockr_option("data_dir", ""),
         )
       )
     },
-    server = function(..., session) {
+    server = function(board, ..., session) {
       ns <- session$ns
 
       # Register directory listing endpoint (directories only)
@@ -172,7 +172,7 @@ new_data_dir_option <- function(value = blockr_option("data_dir", ""),
           {
             val <- session$input[["data_dir_browse"]] %||% ""
             val <- normalizePath(val, winslash = "/")
-            set_board_option_value("data_dir", val, session)
+            set_board_option_value("data_dir", val, board$board, session)
             # Update input to normalized path
             session$sendCustomMessage("blockr-path-set-value", list(
               id = ns("data_dir_browse"),


### PR DESCRIPTION
## Why

Same #230 regression as the scale-map crash: `set_board_option_value()` gained a `board` parameter and gates on `is_board_locked(board)`. This stale 3-arg caller passed `session` into the `board` slot, which crashes the session via `no applicable method for 'is_board_locked' ... "ShinySession"` whenever the data-dir option is set.

## What

- `new_data_dir_option()`'s server now takes `board` (supplied by blockr.core as `board = make_read_only(rv)`).
- Threads `board$board` into the 4-arg `set_board_option_value()`, matching `blockr.core` board-options.R:203.

Part of BristolMyersSquibb/blockr.core#236.