### PR TITLE
Prefer nanoparquet for parquet reads; pass board in data-dir option

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,6 +52,7 @@ Imports:
 Suggests:
     arrow,
     knitr,
+    nanoparquet,
     rmarkdown,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3

--- a/R/data-dir.R
+++ b/R/data-dir.R
@@ -47,7 +47,7 @@ new_data_dir_option <- function(value = blockr_option("data_dir", ""),
         )
       )
     },
-    server = function(..., session) {
+    server = function(board, ..., session) {
       ns <- session$ns
 
       # Register directory listing endpoint (directories only)
@@ -172,7 +172,7 @@ new_data_dir_option <- function(value = blockr_option("data_dir", ""),
           {
             val <- session$input[["data_dir_browse"]] %||% ""
             val <- normalizePath(val, winslash = "/")
-            set_board_option_value("data_dir", val, session)
+            set_board_option_value("data_dir", val, board$board, session)
             # Update input to normalized path
             session$sendCustomMessage("blockr-path-set-value", list(
               id = ns("data_dir_browse"),

--- a/R/expr.R
+++ b/R/expr.R
@@ -173,21 +173,36 @@ read_expr_excel <- function(path, ...) {
 #' @param path Character. File path
 #' @param ... Reading parameters (currently unused)
 #'
-#' @return Expression calling arrow::read_parquet, arrow::read_feather, or arrow::read_ipc_file
+#' @return Expression calling nanoparquet::read_parquet (preferred) or
+#'   arrow::read_parquet for parquet, and arrow::read_feather /
+#'   arrow::read_ipc_file for the Arrow-only feather and IPC formats
 #' @keywords internal
 read_expr_arrow <- function(path, ...) {
   ext <- tolower(tools::file_ext(path))
 
   path <- unname(path)
 
+  # Parquet: prefer nanoparquet (tiny, zero-dependency) when installed, and
+  # fall back to arrow otherwise — e.g. a validated environment that only
+  # whitelists arrow. Feather and Arrow IPC are arrow-only formats.
   if (ext == "parquet") {
-    bquote(arrow::read_parquet(.(path)))
+    read_parquet_expr(path)
   } else if (ext == "feather") {
     bquote(arrow::read_feather(.(path)))
   } else if (ext == "arrow") {
     bquote(arrow::read_ipc_file(.(path)))
   } else {
     # Default to parquet if extension unclear
+    read_parquet_expr(path)
+  }
+}
+
+# Pick the parquet reader expression based on what is installed: prefer
+# nanoparquet (lightweight, zero-dependency), fall back to arrow.
+read_parquet_expr <- function(path) {
+  if (requireNamespace("nanoparquet", quietly = TRUE)) {
+    bquote(nanoparquet::read_parquet(.(path)))
+  } else {
     bquote(arrow::read_parquet(.(path)))
   }
 }

--- a/man/read_expr_arrow.Rd
+++ b/man/read_expr_arrow.Rd
@@ -12,7 +12,9 @@ read_expr_arrow(path, ...)
 \item{...}{Reading parameters (currently unused)}
 }
 \value{
-Expression calling arrow::read_parquet, arrow::read_feather, or arrow::read_ipc_file
+Expression calling nanoparquet::read_parquet (preferred) or
+arrow::read_parquet for parquet, and arrow::read_feather /
+arrow::read_ipc_file for the Arrow-only feather and IPC formats
 }
 \description{
 Create Arrow file reading expression


### PR DESCRIPTION
## What

Two changes needed for the blockr.sandbox deploy that reads parquet from a shared drive:

1. **Lightweight parquet reading.** The read block hardcoded `arrow::read_parquet`, which forced `arrow` (114 MB + a large tidyverse closure, and a C++20 source build that fails on RHEL 8) into any deployment that reads parquet. We now prefer **nanoparquet** (~1 MB, zero dependencies, pure C — builds anywhere) and **fall back to arrow** when nanoparquet isn't installed (e.g. a validated environment that only whitelists arrow). Feather and Arrow IPC stay arrow-only. Both readers remain in `Suggests` — neither is forced on consumers; the reader is chosen at expression-build time via `requireNamespace()`.

2. **data-dir option board arg.** `Pass board to set_board_option_value in data-dir option` (already on this branch).

## Why nanoparquet is safe here

- Reads standard parquet written by arrow to **identical data** (verified locally with a round-trip).
- More deploy-robust than arrow: no system deps, no C++20 toolchain requirement.
- An arrow-only environment is unaffected — the `requireNamespace` fallback keeps emitting `arrow::read_parquet` there.

## Downstream

blockr.sandbox's deploy swaps its forced `Imports: arrow` to `Imports: nanoparquet` so the deploy ships the light reader; this PR is what makes the read block actually use it.