### PR TITLE
Add file_policy to pkgdown reference index (fix pkgdown CI)

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -20,6 +20,7 @@ reference:
   contents:
   - file_category
   - file_extensions
+  - file_policy
   - format_extension
   - new_data_dir_option
   - path_input


### PR DESCRIPTION
## What

pkgdown has been failing on main with:

```
! In _pkgdown.yml, 1 topic missing from index: "file_policy".
```

`file_policy` documents the exported file-access policy API (`resolve_and_check()`, `within_dirs()`) that arrived with the file-access verification work (#25) but was never added to `_pkgdown.yml`. This adds it to the **Utilities** section.

## Verification

Ran the exact check pkgdown CI failed on locally — `pkgdown:::data_reference_index(pkgdown::as_pkgdown("."))` — now builds with no missing/extra topics.

Pure docs/config change; no code touched.