### PR TITLE
Replay path-input restore pushes that arrive before the panel mounts

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: blockr.io
 Title: Interactive File Import and Export Blocks
-Version: 0.1.0.9003
+Version: 0.1.0.9004
 Authors@R:
     c(person(given = "Christoph",
              family = "Sax",

--- a/R/path-input.R
+++ b/R/path-input.R
@@ -342,7 +342,7 @@ list_dir_response <- function(path_val, dir_root = "", mode = "file",
 path_input_dep <- memoise0(function() {
   htmltools::htmlDependency(
     name = "blockr-path-input",
-    version = "0.3.0",
+    version = "0.4.0",
     src = system.file("assets", package = "blockr.io"),
     script = "js/path-input.js",
     stylesheet = "css/path-input.css"

--- a/inst/assets/js/path-input.js
+++ b/inst/assets/js/path-input.js
@@ -35,6 +35,29 @@
     return state[inputId];
   }
 
+  // ----------------------------------------------------------------------
+  // Replay queue (mirrors blockr.dplyr's blockr-core.js _enqueue/_replay):
+  // inside a dockview panel the input reaches the DOM only when the panel
+  // mounts, which can be long after the server flushed its restore
+  // messages. A message that finds no element is held here, keyed by input
+  // id, and replayed when the element turns up (binding initialize / init
+  // scan). No expiry: a never-mounted panel just keeps its pending entry.
+  // ----------------------------------------------------------------------
+  var pending = {};
+
+  function replayPending(inputId) {
+    var msgs = pending[inputId];
+    if (!msgs) return;
+    delete pending[inputId];
+    if (msgs.setValue) applySetValue(msgs.setValue);
+    if (msgs.status) applyStatus(msgs.status);
+  }
+
+  function enqueue(inputId, kind, msg) {
+    if (!pending[inputId]) pending[inputId] = {};
+    pending[inputId][kind] = msg;
+  }
+
   // --------------------------------------------------------------------
   // Shiny input binding: commit on "change" only (Enter / blur / dropdown
   // selection). This replaces the default text binding, which would send
@@ -60,6 +83,12 @@
       },
       unsubscribe: function(el) {
         $(el).off(".blockrPathText");
+      },
+      // Runs when Shiny binds the input -- for dockview panels that is the
+      // late bindAll on layout change, i.e. the first moment the element is
+      // guaranteed to exist. Replay whatever the server pushed too early.
+      initialize: function(el) {
+        replayPending(el.id);
       }
     });
     Shiny.inputBindings.register(pathBinding, "blockr.pathText", 100);
@@ -168,22 +197,28 @@
     st.listUrl = msg.url;
   });
 
-  // Custom message handler: set input value programmatically
+  // Set input value programmatically.
   // msg.silent: if true, only update the display without triggering change
-  Shiny.addCustomMessageHandler("blockr-path-set-value", function(msg) {
+  function applySetValue(msg) {
     var el = document.getElementById(msg.id);
-    if (el) {
-      var st = getState(msg.id);
-      el.value = msg.value || "";
-      // Programmatic values are already applied — treat as committed
-      st.committed = el.value;
-      // Scroll to end so filename is visible
-      el.scrollLeft = el.scrollWidth;
-      updatePrefixVisibility(msg.id);
-      updateChip(msg.id);
-      if (!msg.silent) {
-        $(el).trigger("change");
-      }
+    var st = getState(msg.id);
+    el.value = msg.value || "";
+    // Programmatic values are already applied — treat as committed
+    st.committed = el.value;
+    // Scroll to end so filename is visible
+    el.scrollLeft = el.scrollWidth;
+    updatePrefixVisibility(msg.id);
+    updateChip(msg.id);
+    if (!msg.silent) {
+      $(el).trigger("change");
+    }
+  }
+
+  Shiny.addCustomMessageHandler("blockr-path-set-value", function(msg) {
+    if (document.getElementById(msg.id)) {
+      applySetValue(msg);
+    } else {
+      enqueue(msg.id, "setValue", msg);
     }
   });
 
@@ -443,10 +478,14 @@
       input.dataset.blockrInit = "true";
 
       var inputId = input.id;
+      // A restore push may have arrived before this element existed (lazy
+      // dockview panel): apply it now, before committed-state bookkeeping.
+      replayPending(inputId);
       var st = getState(inputId);
       st.committed = input.value;
       ensureChip(inputId);
       updateRequiredState(inputId);
+      updatePrefixVisibility(inputId);
 
       // Track every commit (Enter, blur, selection, programmatic trigger):
       // jQuery-bound so both native change events and $().trigger("change")
@@ -565,8 +604,10 @@
     });
   }
 
-  // Custom message handler: file-type status badge
-  Shiny.addCustomMessageHandler("blockr-path-status", function(msg) {
+  // File-type status badge. The badge element lives next to the input, so
+  // element presence is checked on the input id and the same replay queue
+  // applies.
+  function applyStatus(msg) {
     var el = document.getElementById(msg.id + "_status");
     if (!el) return;
     if (msg.state === "success" && msg.text) {
@@ -580,6 +621,14 @@
         escapeHtml(msg.text) + '</span>';
     } else {
       el.innerHTML = "";
+    }
+  }
+
+  Shiny.addCustomMessageHandler("blockr-path-status", function(msg) {
+    if (document.getElementById(msg.id + "_status")) {
+      applyStatus(msg);
+    } else {
+      enqueue(msg.id, "status", msg);
     }
   });
 


### PR DESCRIPTION
## Problem

Inside a dockview panel the path input reaches the DOM only when the panel *mounts*. With lazy views and deferred construction that happens long after the block server flushed its restore messages, so `blockr-path-set-value` and `blockr-path-status` found no element and were silently dropped — restored `read`/`write`/`dm_read`/`dm_write` blocks came back with a blank path box (state and evaluation were intact, only the UI was empty).

## Fix

Mirror `blockr.dplyr`'s `blockr-core.js` queue: hold early messages keyed by input id and replay them
- from the binding's `initialize()` (dockview's late `bindAll`), and
- from the init scan.

Dependency version bumped so clients drop the cached script.

## Notes

Paired with the equivalent fix in **blockr.dm** (`Queue table-picker and value-filter pushes until their panel mounts`) — same lazy-panel-mount race.