### PR TITLE
Fill positional slot names in write_expr with distinct defaults

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # blockr.io (development version)
 
+## Bug fixes
+
+- `write_expr()` now fills empty (positional) slot display names with
+  `data_1`, `data_2`, ... instead of using them verbatim. Variadic links
+  added positionally (the blockr.ui / blockr.dock link menus) arrive with
+  `""` names, which produced colliding `.csv` entries inside multi-input
+  ZIP downloads (each write clobbering the last) and empty Excel sheet
+  names.
+
 ## Design-system alignment
 
 - The gear button on the read, write, and download blocks now expands a

--- a/R/write-expr.R
+++ b/R/write-expr.R
@@ -279,10 +279,18 @@ write_expr <- function(
     return(NULL)
   }
 
-  # Ensure data_names has names
-  if (is.null(names(data_names))) {
-    names(data_names) <- as.character(seq_along(data_names))
+  # Ensure every entry has a display name. Positional (unnamed) variadic
+  # slots arrive as "" (or NULL when all are unnamed): left as-is they
+  # produce colliding file names ("" -> ".csv", each write clobbering the
+  # last) and empty Excel sheet names. Fill blanks with a positional
+  # default instead.
+  nms <- names(data_names)
+  if (is.null(nms)) {
+    nms <- character(length(data_names))
   }
+  blank <- !nzchar(nms)
+  nms[blank] <- paste0("data_", which(blank))
+  names(data_names) <- make.unique(nms, sep = "_")
 
   # Generate base filename
   base_filename <- generate_filename(filename)

--- a/tests/testthat/test-write-expr.R
+++ b/tests/testthat/test-write-expr.R
@@ -163,8 +163,68 @@ test_that("write_expr adds names if missing", {
   # Without names
   expr <- write_expr(c("df1", "df2"), "/tmp", "output", "csv")
 
-  # Should still work and add numeric names
+  # Should still work and add positional names
   expect_true(inherits(expr, "call") || is.language(expr))
+})
+
+test_that("write_expr names positional slots distinctly", {
+  skip_if_not_installed("readr")
+  skip_if_not_installed("zip")
+
+  # Positional variadic slots (links added without a name) arrive with ""
+  # display names; each entry still needs a distinct file name or the
+  # writes clobber each other inside the ZIP.
+  df1 <- data.frame(x = 1:3)
+  df2 <- data.frame(y = 4:6)
+
+  out_dir <- tempfile("write_expr_")
+  zip_path <- file.path(out_dir, "output.zip")
+  expr <- write_expr(
+    stats::setNames(c("df1", "df2"), c("", "")),
+    out_dir,
+    "output",
+    "csv"
+  )
+
+  # The multi-file expression rebinds `temp_dir` in the eval env, so keep
+  # the output paths in differently-named locals.
+  eval(expr)
+
+  temp_extract <- tempfile("extract_")
+  dir.create(temp_extract)
+  zip::unzip(zip_path, exdir = temp_extract)
+
+  expect_setequal(
+    list.files(temp_extract, pattern = "\\.csv$"),
+    c("data_1.csv", "data_2.csv")
+  )
+
+  unlink(c(out_dir, temp_extract), recursive = TRUE)
+})
+
+test_that("write_expr mixes named and positional slots without collision", {
+  skip_if_not_installed("writexl")
+  skip_if_not_installed("readxl")
+
+  named <- data.frame(a = 1)
+  unnamed <- data.frame(b = 2)
+
+  temp_dir <- tempfile("write_expr_")
+  expr <- write_expr(
+    stats::setNames(c("named", "unnamed"), c("samples", "")),
+    temp_dir,
+    "output",
+    "excel"
+  )
+
+  eval(expr)
+
+  expect_setequal(
+    readxl::excel_sheets(file.path(temp_dir, "output.xlsx")),
+    c("samples", "data_2")
+  )
+
+  unlink(temp_dir, recursive = TRUE)
 })
 
 


### PR DESCRIPTION
## Symptom

Variadic links added positionally reach the download/write blocks with `""` display names. `write_expr()` used those verbatim for file and Excel-sheet names, so a multi-input download produced colliding `.csv` entries (each write clobbering the last inside the ZIP) and empty sheet names. The blockr.ui link menu has emitted positional slots since Jul 1 (`2945271`); blockr.dock aligns in BristolMyersSquibb/blockr.dock#335.

## Change

- `write_expr()` fills blank display names with `data_1`, `data_2`, ... (positional index) and de-duplicates against user-set names.
- Tests: positional slots produce `data_1.csv` / `data_2.csv` in the ZIP; a named (`samples`) + positional mix yields Excel sheets `samples`, `data_2`.

## Verification

Live dock board (mtcars + iris -> Download, positional links), download fetched headlessly: CSV ZIP entries `data_1.csv` (mtcars) + `data_2.csv` (iris); Excel sheets `data_1`, `data_2`. Suite green except the pre-existing `test-path-input.R` version-pin failure (0.3.0 vs 0.4.0, fails on clean main too).

## Note

`data_N` is a collision-safe default, not the meaningful name the ALLM QC dashboard wants. Naming after the upstream block cannot be done here: positional slots reach the block server with hidden synthetic keys and no origin metadata, so that needs either a settable name in the dock link menu or new blockr.core surface. Decision pending with @christophsax.