### PR TITLE
ci(io): document resolve_data_dir()'s arguments

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -41,6 +41,10 @@ set_names <- function(x, nm) {
 #' from the path widget beside it, reading one file while showing another.
 #' Exported so there is one answer.
 #'
+#' @param paths Character vector of paths, each absolute, relative or a URL.
+#' @param data_dir The board's data directory. `""` (the default) leaves every
+#'   path alone, which is what a board without one wants.
+#' @return `paths`, unnamed, with the relative ones prefixed by `data_dir`.
 #' @export
 resolve_data_dir <- function(paths, data_dir = "") {
   if (!length(paths) || !nzchar(data_dir)) {

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -25,5 +25,6 @@ reference:
   - new_data_dir_option
   - path_input
   - read_file_expr
+  - resolve_data_dir
   - write_file_expr
   - write_formats

--- a/man/resolve_data_dir.Rd
+++ b/man/resolve_data_dir.Rd
@@ -6,6 +6,15 @@
 \usage{
 resolve_data_dir(paths, data_dir = "")
 }
+\arguments{
+\item{paths}{Character vector of paths, each absolute, relative or a URL.}
+
+\item{data_dir}{The board's data directory. \code{""} (the default) leaves every
+path alone, which is what a board without one wants.}
+}
+\value{
+\code{paths}, unnamed, with the relative ones prefixed by \code{data_dir}.
+}
 \description{
 Relative paths are taken to be relative to the data directory; absolute
 ones and URLs are left alone. Vectorized, so a multi-file read resolves in


### PR DESCRIPTION
`smoke` on main has been red since 81bc3eb:

```
checking Rd \usage sections ... WARNING
  Undocumented arguments in Rd file 'resolve_data_dir.Rd'
    'paths' 'data_dir'
```

`resolve_data_dir()` is `@export`ed but its roxygen block never described either argument. Adds `@param` for both plus a `@return`.

Worth knowing: `check`, `coverage` and `pkgdown` all declare `needs: smoke`, so this one WARNING has been skipping **the entire pipeline** — the four-platform check matrix included. And `check` is `if: github.event_name != 'pull_request'`, so it will not run on this PR either; it only runs once this lands on main.

Separately: the `lint` job in `ci.yaml` is commented out ("Temporarily disabled linting"). Left alone here.